### PR TITLE
clang fix

### DIFF
--- a/c/nitf/include/nitf/PluginIdentifier.h
+++ b/c/nitf/include/nitf/PluginIdentifier.h
@@ -15,7 +15,8 @@
 /*! The TRE plugin key is dependent on the NITF library version. Thus, only
  * plugins built with the same version of the library will be loaded
  */
-#define NITF_PLUGIN_TRE_KEY             "TRE:"NITF_LIB_VERSION
+#define NITRO_STRINGIFY(x) #x
+#define NITF_PLUGIN_TRE_KEY             NITRO_STRINGIFY(TRE:)NITF_LIB_VERSION
 #define NITF_PLUGIN_COMPRESSION_KEY     "COMPRESSION"
 #define NITF_PLUGIN_DECOMPRESSION_KEY   "DECOMPRESSION"
 


### PR DESCRIPTION
seems to fix PDAL build for clang, but should be tested on other plats

(for nitro issue #2)
